### PR TITLE
Don't crash when receiving a message from a channel

### DIFF
--- a/lib/app/commander.ex
+++ b/lib/app/commander.ex
@@ -158,6 +158,8 @@ defmodule App.Commander do
           id
         %{edited_message: %{chat: %{id: id}}} when not is_nil(id) -> 
           id
+        %{channel_post: %{chat: %{id: id}}} when not is_nil(id) ->
+          id
         _ -> raise "No chat id found!"
       end
     end


### PR DESCRIPTION
It still always answers with `Sorry, I couldn't understand you` even if it should receive a correct command. Probably somewhere it also matches for a message the wrong way. But at least it doesn't crash anymore :-) 